### PR TITLE
Fast swiping bug

### DIFF
--- a/MXPagerView/MXPagerView.m
+++ b/MXPagerView/MXPagerView.m
@@ -347,7 +347,7 @@
     NSInteger position  = scrollView.contentOffset.x;
     NSInteger width     = scrollView.bounds.size.width;
     
-    NSInteger index = floor(position/width);
+    NSInteger index = position / width;
     if (index >= 0) {
         [self didMovePageToIndex:index];
     }
@@ -366,7 +366,7 @@
     NSInteger position  = targetContentOffset->x;
     NSInteger width     = scrollView.bounds.size.width;
     
-    NSInteger index = floor(position/width);
+    NSInteger index = position / width;
     if (index >= 0) {
         [self willMovePageToIndex:index];
     }

--- a/MXPagerView/MXPagerView.m
+++ b/MXPagerView/MXPagerView.m
@@ -222,22 +222,20 @@
 #pragma mark Private Methods
 
 - (void) willMovePageToIndex:(NSInteger) index {
-    if (index != _index) {
-        [self loadPageAtIndex:index];
-        
-        if ([self.delegate respondsToSelector:@selector(pagerView:willMoveToPageAtIndex:)]) {
-            [self.delegate pagerView:self willMoveToPageAtIndex:index];
-        }
-        
-        if ([self.delegate respondsToSelector:@selector(pagerView:willHidePage:)]) {
-            UIView *page = [self pageAtIndex:_index];
-            [self.delegate pagerView:self willHidePage:page];
-        }
-        
-        if ([self.delegate respondsToSelector:@selector(pagerView:willShowPage:)]) {
-            UIView *page = [self pageAtIndex:index];
-            [self.delegate pagerView:self willShowPage:page];
-        }
+    [self loadPageAtIndex:index];
+    
+    if ([self.delegate respondsToSelector:@selector(pagerView:willMoveToPageAtIndex:)]) {
+        [self.delegate pagerView:self willMoveToPageAtIndex:index];
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(pagerView:willHidePage:)]) {
+        UIView *page = [self pageAtIndex:_index];
+        [self.delegate pagerView:self willHidePage:page];
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(pagerView:willShowPage:)]) {
+        UIView *page = [self pageAtIndex:index];
+        [self.delegate pagerView:self willShowPage:page];
     }
 }
 
@@ -349,8 +347,9 @@
     NSInteger position  = scrollView.contentOffset.x;
     NSInteger width     = scrollView.bounds.size.width;
     
-    if (!(position % width)) {
-        [self didMovePageToIndex:(position / width)];
+    NSInteger index = floor(position/width);
+    if (index >= 0) {
+        [self didMovePageToIndex:index];
     }
     
     if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) {
@@ -367,9 +366,11 @@
     NSInteger position  = targetContentOffset->x;
     NSInteger width     = scrollView.bounds.size.width;
     
-    if (!(position % width)) {
-        [self willMovePageToIndex:(position / width)];
+    NSInteger index = floor(position/width);
+    if (index >= 0) {
+        [self willMovePageToIndex:index];
     }
+
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {

--- a/MXPagerView/MXPagerView.m
+++ b/MXPagerView/MXPagerView.m
@@ -370,7 +370,6 @@
     if (index >= 0) {
         [self willMovePageToIndex:index];
     }
-
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {


### PR DESCRIPTION
This PR address 2 things:
1. Currently, when you swipe really quickly within the pager, you'll notice that sometimes, the segmented control lags behind and doesn't rest on the index that it was last left to. Super easy to reproduce if you scroll in one direction, and before the animation is fully complete (before `didEndDecelerating`), swipe back to the previous screen. It seemed, it assumed the indices were the same and didn't actually process that swipe like it should.
2. On an iPad, when the pager is used inside a SplitViewController, 100% of the time, it seems the calculation of the `targetContentOffset` returned doesn't result in a modulo of 0 like we were expecting, therefore the segmented control failed to update. This PR changes how that index is calculated so it works on both types of devices/screens. 
