### PR TITLE
Set the new index value before we call our delegate methods

### DIFF
--- a/MXPagerView/MXPagerView.m
+++ b/MXPagerView/MXPagerView.m
@@ -244,6 +244,8 @@
 - (void) didMovePageToIndex:(NSInteger)index {
     if (index != _index) {
         
+        _index = index;
+
         if ([self.delegate respondsToSelector:@selector(pagerView:didMoveToPageAtIndex:)]) {
             [self.delegate pagerView:self didMoveToPageAtIndex:index];
         }
@@ -257,9 +259,7 @@
             UIView *page = [self pageAtIndex:index];
             [self.delegate pagerView:self didShowPage:page];
         }
-        
-        _index = index;
-        
+                
         //The page did change, now unload hidden pages
         [self unLoadHiddenPages];
     }


### PR DESCRIPTION
This PR calls `_index = index` right before calling the subsequent delegate methods 

so that any calls to `segmentedPager.pager.indexForSelectedPage` inside those delegate methods will return the correct index that the segmentedPager did move to.
